### PR TITLE
Use grep -q instead of shell `contains` function

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "letsencrypt.sh"]
 	path = letsencrypt.sh
 	url = https://github.com/lukas2511/letsencrypt.sh.git
+[submodule "dehydrated"]
+	path = dehydrated
+	url = ./dehydrated

--- a/nfsn-cron.sh
+++ b/nfsn-cron.sh
@@ -15,16 +15,16 @@ cd "$(dirname "$0")"
 echo " + Updating lets-nfsn.sh..."
 git pull
 
-echo " + Updating letsencrypt.sh..."
+echo " + Updating dehydrated..."
 git submodule update --remote
-cd letsencrypt.sh
+cd dehydrated
 
 echo " + Checking certificate expiration date..."
 declare -a checks=( $(find certs -name cert.pem -type l -exec openssl x509 -checkend 2592000 -in {} \;) )
 if grep -q "Certificate will expire" <<<"${checks[@]}"; then
 	echo " + Certificate will expire in 30 days or less! SSH into this site and"
 	echo "   run the following commands to renew your certificates:"
-	echo "	cd ~/lets-nfsn.sh/letsencrypt.sh/"
+	echo "	cd ~/lets-nfsn.sh/dehydrated/"
 	echo "	./letsencrypt.sh --cron"
 	echo " + This error message will repeat daily."
 	exit 1

--- a/nfsn-cron.sh
+++ b/nfsn-cron.sh
@@ -21,8 +21,8 @@ cd letsencrypt.sh
 
 echo " + Checking certificate expiration date..."
 declare -a checks=( $(find certs -name cert.pem -type l -exec openssl x509 -checkend 2592000 -in {} \;) )
-if contains "Certificate will expire" "${checks[@]}"; then
-	echo " + Certificte will expire in 30 days or less! SSH into this site and"
+if grep -q "Certificate will expire" <<<"${checks[@]}"; then
+	echo " + Certificate will expire in 30 days or less! SSH into this site and"
 	echo "   run the following commands to renew your certificates:"
 	echo "	cd ~/lets-nfsn.sh/letsencrypt.sh/"
 	echo "	./letsencrypt.sh --cron"


### PR DESCRIPTION
The `contains` function apparently always returns false on my shell, resulting in the cron job never detecting that the certificate expired ( GNU bash, version 4.3.42(1)-release (amd64-portbld-freebsd10.2) ).

I think `grep -q` is more likely to be portable.